### PR TITLE
Setup Dockerfile to Deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12
+FROM node:16.0.0-alpine3.13
 
 WORKDIR /project
 COPY package.json .

--- a/README.md
+++ b/README.md
@@ -36,5 +36,30 @@ docker compose up
 docker compose up -d # detached so that the server keeps running even if terminal goes away
 ```
 
+# Deploying Image to our docker repository
+```
+docker build --push -t registry.digitalocean.com/nftnft:0.2.0-test .
+```
+
+## M1 Silicon Only Notes
+
+To properly push images to our docker registry, follow these instructions:
+https://betterprogramming.pub/how-to-actually-deploy-docker-images-built-on-a-m1-macs-with-apple-silicon-a35e39318e97
+
+In a nutshell:
+
+Set up and use your builder.
+```
+docker buildx create --name m1_builder
+docker buildx use m1_builder
+docker buildx inspect --bootstrap
+```
+
+Then build/push your image:
+```
+docker buildx build --platform linux/amd64  --push -t registry.digitalocean.com/nftnft/calendar:0.2.0-test .
+```
+
+
 
 


### PR DESCRIPTION
related: https://github.com/nftnft/operations/pull/1

Here, I'm just updating the Dockerfile to make the image small enough for us to cheaply deploy it.
Alpine images are built off a super lightweight "busybox" linux image.
 